### PR TITLE
add architecture notes index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ in [docs/support.md](/Users/Apple/dev/os/mann/Substrata/docs/support.md).
 ### Added
 
 - Initial repository scaffolding and package foundation for the Substrata SDK.
+- Architecture notes index for ADRs and implementation references.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ ruff check .
 Project docs index:
 
 - [docs/index.md](/Users/Apple/dev/os/mann/Substrata/docs/index.md)
+- [docs/architecture/README.md](/Users/Apple/dev/os/mann/Substrata/docs/architecture/README.md)
 
 ## Open Source Standards
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,32 @@
+# Architecture Notes Index
+
+This directory is the home for committed architecture notes, ADRs, and
+implementation references that explain how the Substrata package is organized.
+
+## Purpose
+
+- Capture stable design decisions that should survive beyond one issue or pull request.
+- Keep package-boundary notes discoverable for contributors who are new to the repo.
+- Provide one place to link future ADRs and implementation references without
+  duplicating the README.
+
+## Current Notes
+
+- Package foundation overview:
+  [docs/architecture/foundation.md](/Users/Apple/dev/os/mann/Substrata/docs/architecture/foundation.md)
+- Package foundation and entrypoints:
+  [README.md](/Users/Apple/dev/os/mann/Substrata/README.md)
+- Development workflow and local commands:
+  [docs/development.md](/Users/Apple/dev/os/mann/Substrata/docs/development.md)
+
+## Future Additions
+
+- ADRs for payment orchestration, signer integrations, and policy evaluation
+- Service-layer notes for wallet, provider, and x402 flows
+- Reference docs for shared models, validation, and serialization helpers
+
+## Maintenance Notes
+
+- Prefer one note per decision or subsystem instead of a single long design document.
+- Link to canonical implementation or API docs when a note depends on active code.
+- Move issue-only context here only after it is rewritten into durable repository guidance.

--- a/docs/architecture/foundation.md
+++ b/docs/architecture/foundation.md
@@ -1,0 +1,42 @@
+# Package Foundation Notes
+
+This note captures the current package shape after the initial Substrata
+foundation work landed.
+
+## Entrypoints
+
+- `python -m substrata` runs [substrata/__main__.py](/Users/Apple/dev/os/mann/Substrata/substrata/__main__.py)
+  and routes into the package CLI.
+- `python main.py` stays available as a compatibility entrypoint and delegates
+  to [substrata/cli.py](/Users/Apple/dev/os/mann/Substrata/substrata/cli.py).
+- `python examples/basic_app.py` exercises the package from an external example
+  path instead of using ad hoc root-level script logic.
+
+## Core Modules
+
+- [substrata/constants.py](/Users/Apple/dev/os/mann/Substrata/substrata/constants.py)
+  defines shared environment and network values.
+- [substrata/config.py](/Users/Apple/dev/os/mann/Substrata/substrata/config.py)
+  loads typed runtime settings from environment variables.
+- [substrata/logging.py](/Users/Apple/dev/os/mann/Substrata/substrata/logging.py)
+  centralizes logging bootstrap behavior.
+- [substrata/errors.py](/Users/Apple/dev/os/mann/Substrata/substrata/errors.py)
+  defines the base error taxonomy used by foundation code.
+- [substrata/app.py](/Users/Apple/dev/os/mann/Substrata/substrata/app.py)
+  contains the minimal runnable application surface.
+
+## Testing and Tooling
+
+- [tests/test_foundations.py](/Users/Apple/dev/os/mann/Substrata/tests/test_foundations.py)
+  covers public exports, typed errors, and logging setup.
+- [tests/test_config.py](/Users/Apple/dev/os/mann/Substrata/tests/test_config.py)
+  covers settings loading and validation behavior.
+- [pyproject.toml](/Users/Apple/dev/os/mann/Substrata/pyproject.toml)
+  defines the package metadata, pytest configuration, and Ruff rules used in CI.
+
+## Follow-on Architecture Notes
+
+- Add ADRs when wallet, signer, policy, and x402 subsystems introduce
+  cross-cutting decisions that should not live only in issue threads.
+- Prefer one short note per subsystem or decision so later contributors can
+  locate rationale without reading a large design document.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ This directory is the starting point for committed project documentation.
 
 - Repository overview: [`README.md`](/Users/Apple/dev/os/mann/Substrata/README.md)
 - Development guide: [`docs/development.md`](/Users/Apple/dev/os/mann/Substrata/docs/development.md)
+- Architecture notes index: [`docs/architecture/README.md`](/Users/Apple/dev/os/mann/Substrata/docs/architecture/README.md)
 - Issue-writing guidance: [`docs/issue-writing.md`](/Users/Apple/dev/os/mann/Substrata/docs/issue-writing.md)
 - Triage guidance: [`docs/triage.md`](/Users/Apple/dev/os/mann/Substrata/docs/triage.md)
 - Maintainer guide: [`docs/maintainers.md`](/Users/Apple/dev/os/mann/Substrata/docs/maintainers.md)
@@ -13,9 +14,9 @@ This directory is the starting point for committed project documentation.
 
 ## Planned Doc Areas
 
-- Architecture notes for package boundaries and service layers
 - Integration guides for wallet, signer, policy, and x402 subsystems
 - Contributor-focused debugging and local development references
+- Deeper ADRs for package boundaries and service layers
 
 ## Maintenance Notes
 


### PR DESCRIPTION
Adds a lightweight architecture notes home and links it from the docs entry points.

Closes #22